### PR TITLE
fix(HamburgerMenu.jsx): fixed a bug related to transition of scroll.

### DIFF
--- a/src/components/HamburgerMenu/HamburgerMenu.jsx
+++ b/src/components/HamburgerMenu/HamburgerMenu.jsx
@@ -28,7 +28,7 @@ const HamburgerMenu = memo(() => {
 
   return createPortal(
     <div
-      className={`fixed top-0 h-[100dvh] w-full bg-black/50 transition-all ${isShowHamburgerMenu ? 'z-30 backdrop-blur-xs' : 'z-[-1] backdrop-blur-[0]'}`}
+      className={`fixed top-0 h-[100dvh] w-full bg-black/50 transition-[backdrop-filter,z-index] ${isShowHamburgerMenu ? 'z-30 backdrop-blur-xs' : 'z-[-1] backdrop-blur-[0]'}`}
       // close the menu if use clicks outside of menu box
       onClick={(e) => e.target === e.currentTarget && setIsShowHamburgerMenu(false)}
     >


### PR DESCRIPTION
- when user scrolls the page while menu is open, the height of menu would sometimes not be updated correctly, causing the menu to have shorter height than expected.