### PR TITLE
fix(Layout.jsx): Resolve footer overlap issue on mobile devices.

### DIFF
--- a/src/components/shared/Layout/Layout.jsx
+++ b/src/components/shared/Layout/Layout.jsx
@@ -62,7 +62,7 @@ export default function Layout() {
             </div>
           </div>
         </div>
-        <div className="flex grow flex-col items-start gap-12 pt-6 pb-10">
+        <div className="flex grow flex-col items-start gap-12 pt-6 pb-32 lg:pb-10">
           <Outlet />
           <Player />
           <Footer />


### PR DESCRIPTION
Previously, on mobile devices, the music player would overlap with the footer when scrolled to the bottom of the page. This issue has been resolved by increasing the padding-bottom of the container on mobile, effectively fixing the layout on mobile devices.